### PR TITLE
docs: Updated CI badge link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # 📊 kong-plugin-cluster-stats
-[![CI Tests](https://github.com/CRED-CLUB/kong-plugin-cluster-stats/actions/workflows/CI_tests.yml/badge.svg)](https://github.com/CRED-CLUB/kong-plugin-cluster-stats/actions/workflows/CI_tests.yml)
+[![CI Tests](https://github.com/CRED-CLUB/kong-plugin-cluster-stats/workflows/CI%20Tests/badge.svg)](https://github.com/CRED-CLUB/kong-plugin-cluster-stats/actions/workflows/CI_tests.yml)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
 ## Overview


### PR DESCRIPTION
Github badge for CI Tests on readme file shows tests fail whereas they are passing. There was a minor issue with the CI badge link which has been updated.